### PR TITLE
日報の言及機能を実装

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -20,23 +20,19 @@ class ReportsController < ApplicationController
 
   def create
     @report = current_user.reports.new(report_params)
-    mentioned_ids = find_mentioned_ids(@report)
-    @report.transaction do
-      @report.save!
-      mentioned_reports = Report.find(mentioned_ids)
-      @report.mentioning_reports << mentioned_reports
+    if @report.save_report_and_mentioning
+      redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
+    else
+      render :new, status: :unprocessable_entity
     end
-    redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
   end
 
   def update
-    @report.transaction do
-      @report.update!(report_params)
-      mentioned_ids = find_mentioned_ids(@report)
-      mentioned_reports = Report.find(mentioned_ids)
-      @report.mentioning_reports = mentioned_reports
+    if @report.update_report_and_mentioning(report_params)
+      redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
+    else
+      render :edit, status: :unprocessable_entity
     end
-    redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
   end
 
   def destroy
@@ -49,10 +45,6 @@ class ReportsController < ApplicationController
 
   def set_report
     @report = current_user.reports.find(params[:id])
-  end
-
-  def find_mentioned_ids(report)
-    report.content.scan(%r{http://localhost:3000/reports/(.+)}).flatten
   end
 
   def report_params

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -52,7 +52,7 @@ class ReportsController < ApplicationController
   end
 
   def find_mentioned_ids(report)
-    report.content.scan(/http:\/\/localhost:3000\/reports\/(.+)/).flatten
+    report.content.scan(%r{http://localhost:3000/reports/(.+)}).flatten
   end
 
   def report_params

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -27,7 +27,6 @@ class ReportsController < ApplicationController
       @report.mentioning_reports << mentioned_reports
     end
     redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
-    #render :edit, status: :unprocessable_entity
   end
 
   def update

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -9,6 +9,7 @@ class ReportsController < ApplicationController
 
   def show
     @report = Report.find(params[:id])
+    @mentioneds = @report.mentioned_reports.includes(:user)
   end
 
   def new
@@ -19,20 +20,24 @@ class ReportsController < ApplicationController
 
   def create
     @report = current_user.reports.new(report_params)
-
-    if @report.save
-      redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
-    else
-      render :new, status: :unprocessable_entity
+    mentioned_ids = find_mentioned_ids(@report)
+    @report.transaction do
+      @report.save!
+      mentioned_reports = Report.find(mentioned_ids)
+      @report.mentioning_reports << mentioned_reports
     end
+    redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
+    #render :edit, status: :unprocessable_entity
   end
 
   def update
-    if @report.update(report_params)
+      @report.transaction do
+        @report.update!(report_params)
+        mentioned_ids = find_mentioned_ids(@report)
+        mentioned_reports = Report.find(mentioned_ids)
+        @report.mentioning_reports = mentioned_reports
+      end
       redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
-    else
-      render :edit, status: :unprocessable_entity
-    end
   end
 
   def destroy
@@ -45,6 +50,10 @@ class ReportsController < ApplicationController
 
   def set_report
     @report = current_user.reports.find(params[:id])
+  end
+
+  def find_mentioned_ids(report)
+    report.content.scan(/http:\/\/localhost:3000\/reports\/(.+)/).flatten
   end
 
   def report_params

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -30,13 +30,13 @@ class ReportsController < ApplicationController
   end
 
   def update
-      @report.transaction do
-        @report.update!(report_params)
-        mentioned_ids = find_mentioned_ids(@report)
-        mentioned_reports = Report.find(mentioned_ids)
-        @report.mentioning_reports = mentioned_reports
-      end
-      redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
+    @report.transaction do
+      @report.update!(report_params)
+      mentioned_ids = find_mentioned_ids(@report)
+      mentioned_reports = Report.find(mentioned_ids)
+      @report.mentioning_reports = mentioned_reports
+    end
+    redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
   end
 
   def destroy

--- a/app/models/mention.rb
+++ b/app/models/mention.rb
@@ -1,0 +1,7 @@
+class Mention < ApplicationRecord
+  belongs_to :mentioning, class_name: 'Report', inverse_of: :mentioning_relationship
+  belongs_to :mentioned, class_name: 'Report', inverse_of: :mentioned_relationship
+  
+  validates :mentioning_id, presence: true, uniqueness: { scope: :mentioned_id }
+  validates :mentioned_id, presence: true
+end

--- a/app/models/mention.rb
+++ b/app/models/mention.rb
@@ -4,6 +4,5 @@ class Mention < ApplicationRecord
   belongs_to :mentioning, class_name: 'Report', inverse_of: :mentioning_relationship
   belongs_to :mentioned, class_name: 'Report', inverse_of: :mentioned_relationship
 
-  validates :mentioning_id, presence: true, uniqueness: { scope: :mentioned_id }
-  validates :mentioned_id, presence: true
+  validates :mentioning_id, uniqueness: { scope: :mentioned_id }
 end

--- a/app/models/mention.rb
+++ b/app/models/mention.rb
@@ -5,4 +5,12 @@ class Mention < ApplicationRecord
   belongs_to :mentioned, class_name: 'Report', inverse_of: :mentioned_relationship
 
   validates :mentioning_id, uniqueness: { scope: :mentioned_id }
+  validate :prevent_self_reference
+
+  def prevent_self_reference
+    if mentioning_id.equal?(mentioned_id)
+      errors.add(:mentioning, I18n.t('errors.messages.self_reference', model: Report.model_name.human))
+      false
+    end
+  end
 end

--- a/app/models/mention.rb
+++ b/app/models/mention.rb
@@ -8,9 +8,8 @@ class Mention < ApplicationRecord
   validate :prevent_self_reference
 
   def prevent_self_reference
-    if mentioning_id.equal?(mentioned_id)
-      errors.add(:mentioning, I18n.t('errors.messages.self_reference', model: Report.model_name.human))
-      false
-    end
+    return unless mentioning_id.equal?(mentioned_id)
+
+    errors.add(:mentioning, I18n.t('errors.messages.self_reference', model: Report.model_name.human))
   end
 end

--- a/app/models/mention.rb
+++ b/app/models/mention.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 class Mention < ApplicationRecord
   belongs_to :mentioning, class_name: 'Report', inverse_of: :mentioning_relationship
   belongs_to :mentioned, class_name: 'Report', inverse_of: :mentioned_relationship
-  
+
   validates :mentioning_id, presence: true, uniqueness: { scope: :mentioned_id }
   validates :mentioned_id, presence: true
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -25,6 +25,7 @@ class Report < ApplicationRecord
     transaction do
       raise ActiveRecord::Rollback unless save
       raise ActiveRecord::Rollback unless save_mentioning
+
       true
     end
   end
@@ -33,6 +34,7 @@ class Report < ApplicationRecord
     transaction do
       raise ActiveRecord::Rollback unless update(report_params)
       raise ActiveRecord::Rollback unless save_mentioning
+
       true
     end
   end
@@ -42,9 +44,9 @@ class Report < ApplicationRecord
   def prevent_mentioning_not_exist_report
     mentioned_ids = find_mentioned_ids(self)
     reports = Report.where(id: mentioned_ids)
-    unless mentioned_ids.length.equal?(reports.length)
-      errors.add(:mentioning, I18n.t('errors.messages.not_found'))
-    end
+    return if mentioned_ids.length.equal?(reports.length)
+
+    errors.add(:mentioning, I18n.t('errors.messages.not_found'))
   end
 
   def save_mentioning
@@ -62,5 +64,4 @@ class Report < ApplicationRecord
   def find_mentioned_ids(report)
     report.content.scan(%r{http://localhost:3000/reports/(.+)}).flatten
   end
-
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -4,9 +4,9 @@ class Report < ApplicationRecord
   belongs_to :user
   has_many :comments, as: :commentable, dependent: :destroy
   # 自分が言及元＝相手の言及先、なのでforeign_keyはmentioning_idになる
-  has_many :mentioned_relationship, class_name: 'Mention', foreign_key: 'mentioning_id', dependent: :destroy
+  has_many :mentioned_relationship, class_name: 'Mention', foreign_key: 'mentioning_id', dependent: :destroy, inverse_of: :mentioning
   has_many :mentioned_reports, through: :mentioned_relationship, source: :mentioned
-  has_many :mentioning_relationship, class_name: 'Mention', foreign_key: 'mentioned_id', dependent: :destroy
+  has_many :mentioning_relationship, class_name: 'Mention', foreign_key: 'mentioned_id', dependent: :destroy, inverse_of: :mentioned
   has_many :mentioning_reports, through: :mentioning_relationship, source: :mentioning
 
   validates :title, presence: true

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -3,6 +3,11 @@
 class Report < ApplicationRecord
   belongs_to :user
   has_many :comments, as: :commentable, dependent: :destroy
+  # 自分が言及元＝相手の言及先、なのでforeign_keyはmentioning_idになる
+  has_many :mentioned_relationship, class_name: 'Mention', foreign_key: 'mentioning_id', dependent: :destroy
+  has_many :mentioned_reports, through: :mentioned_relationship, source: :mentioned
+  has_many :mentioning_relationship, class_name: 'Mention', foreign_key: 'mentioned_id', dependent: :destroy
+  has_many :mentioning_reports, through: :mentioning_relationship, source: :mentioning
 
   validates :title, presence: true
   validates :content, presence: true

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -19,4 +19,8 @@ class Report < ApplicationRecord
   def created_on
     created_at.to_date
   end
+
+  def posted_by
+    user.name.empty? ? user.email : user.name
+  end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -19,8 +19,4 @@ class Report < ApplicationRecord
   def created_on
     created_at.to_date
   end
-
-  def posted_by
-    user.name.empty? ? user.email : user.name
-  end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -11,6 +11,7 @@ class Report < ApplicationRecord
 
   validates :title, presence: true
   validates :content, presence: true
+  validate :prevent_mentioning_not_exist_report
 
   def editable?(target_user)
     user == target_user
@@ -19,4 +20,47 @@ class Report < ApplicationRecord
   def created_on
     created_at.to_date
   end
+
+  def save_report_and_mentioning
+    transaction do
+      raise ActiveRecord::Rollback unless save
+      raise ActiveRecord::Rollback unless save_mentioning
+      true
+    end
+  end
+
+  def update_report_and_mentioning(report_params)
+    transaction do
+      raise ActiveRecord::Rollback unless update(report_params)
+      raise ActiveRecord::Rollback unless save_mentioning
+      true
+    end
+  end
+
+  private
+
+  def prevent_mentioning_not_exist_report
+    mentioned_ids = find_mentioned_ids(self)
+    reports = Report.where(id: mentioned_ids)
+    unless mentioned_ids.length.equal?(reports.length)
+      errors.add(:mentioning, I18n.t('errors.messages.not_found'))
+    end
+  end
+
+  def save_mentioning
+    mentioned_ids = find_mentioned_ids(self)
+    reports = Report.where(id: mentioned_ids)
+    begin
+      self.mentioning_reports = reports
+      true
+    rescue ActiveRecord::RecordInvalid => e
+      errors.merge!(e.record.errors)
+      false
+    end
+  end
+
+  def find_mentioned_ids(report)
+    report.content.scan(%r{http://localhost:3000/reports/(.+)}).flatten
+  end
+
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -62,6 +62,6 @@ class Report < ApplicationRecord
   end
 
   def find_mentioned_ids(report)
-    report.content.scan(%r{http://localhost:3000/reports/(.+)}).flatten
+    report.content.scan(%r{http://localhost:3000/reports/(.+)}).flatten.uniq
   end
 end

--- a/app/views/reports/_mentions.html.erb
+++ b/app/views/reports/_mentions.html.erb
@@ -1,0 +1,11 @@
+<div class="comments-container">
+  <strong><%= t('views.mention.mentioneds', report: Report.model_name.human, mention: Mention.model_name.human) %></strong>
+  <% mentioneds.each do |mentioned| %>
+    <p>
+      <strong><%= Report.human_attribute_name(:title) %>:</strong>
+      <%= link_to mentioned.title, url_for(mentioned) %>
+      <strong><%= Report.human_attribute_name(:user) %>:</strong>
+      <%= mentioned.user.name %>
+    </p>
+  <% end %>
+</div>

--- a/app/views/reports/_mentions.html.erb
+++ b/app/views/reports/_mentions.html.erb
@@ -5,7 +5,7 @@
       <strong><%= Report.human_attribute_name(:title) %>:</strong>
       <%= link_to mentioned.title, report_path(mentioned) %>
       <strong><%= Report.human_attribute_name(:user) %>:</strong>
-      <%= mentioned.user.name %>
+      <%= mentioned.posted_by %>
     </p>
   <% end %>
 </div>

--- a/app/views/reports/_mentions.html.erb
+++ b/app/views/reports/_mentions.html.erb
@@ -5,7 +5,7 @@
       <strong><%= Report.human_attribute_name(:title) %>:</strong>
       <%= link_to mentioned.title, report_path(mentioned) %>
       <strong><%= Report.human_attribute_name(:user) %>:</strong>
-      <%= mentioned.posted_by %>
+      <%= mentioned.user.name_or_email %>
     </p>
   <% end %>
 </div>

--- a/app/views/reports/_mentions.html.erb
+++ b/app/views/reports/_mentions.html.erb
@@ -1,4 +1,4 @@
-<div class="comments-container">
+<div>
   <strong><%= t('views.mention.mentioneds', report: Report.model_name.human, mention: Mention.model_name.human) %></strong>
   <% mentioneds.each do |mentioned| %>
     <p>

--- a/app/views/reports/_mentions.html.erb
+++ b/app/views/reports/_mentions.html.erb
@@ -3,7 +3,7 @@
   <% mentioneds.each do |mentioned| %>
     <p>
       <strong><%= Report.human_attribute_name(:title) %>:</strong>
-      <%= link_to mentioned.title, url_for(mentioned) %>
+      <%= link_to mentioned.title, report_path(mentioned) %>
       <strong><%= Report.human_attribute_name(:user) %>:</strong>
       <%= mentioned.user.name %>
     </p>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -5,6 +5,7 @@
 </div>
 
 <%= render 'application/comments', commentable: @report %>
+<%= render 'mentions', mentioneds: @mentioneds unless @mentioneds.empty? %>
 
 <nav class="page-nav">
   <% if @report.editable?(current_user) %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -102,11 +102,13 @@ ja:
       model_invalid: 'バリデーションに失敗しました: %{errors}'
       not_a_number: は数値で入力してください
       not_an_integer: は整数で入力してください
+      not_found: が見つかりません
       odd: は奇数にしてください
       other_than: は%{count}以外の値にしてください
       password_too_long: が長すぎます
       present: は入力しないでください
       required: を入力してください
+      self_reference: 'に現在の%{model}は指定できません'
       taken: はすでに存在します
       too_long: は%{count}文字以内で入力してください
       too_short: は%{count}文字以上で入力してください

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -197,6 +197,8 @@ ja:
       validation_error: "%{errors}があるため、この%{name}は保存できませんでした"
       title_show: "%{name}の詳細"
       sign_out: ログアウト
+    mention:
+      mentioneds: "この%{report}は以下の%{report}から%{mention}されています"
     pagination:
       first: '« 最初'
       last: '最後 »'

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -5,6 +5,7 @@ ja:
       user: ユーザ
       report: 日報
       comment: コメント
+      mention: 言及
 
     attributes:
       book:

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -23,4 +23,5 @@ ja:
         title: タイトル
         content: 内容
         user: 作成者
+        mentioning: 言及先
         created_on: 作成日

--- a/db/migrate/20251029024432_create_mentions.rb
+++ b/db/migrate/20251029024432_create_mentions.rb
@@ -1,0 +1,10 @@
+class CreateMentions < ActiveRecord::Migration[8.0]
+  def change
+    create_table :mentions do |t|
+      t.belongs_to :mentioning, null: false, foreign_key: { to_table: :reports }
+      t.belongs_to :mentioned, null: false, foreign_key: { to_table: :reports }
+      t.timestamps
+    end
+    add_index :mentions, [:mentioning_id, :mentioned_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_24_060432) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_29_024432) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -59,6 +59,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_24_060432) do
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
+  create_table "mentions", force: :cascade do |t|
+    t.integer "mentioning_id", null: false
+    t.integer "mentioned_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["mentioned_id"], name: "index_mentions_on_mentioned_id"
+    t.index ["mentioning_id", "mentioned_id"], name: "index_mentions_on_mentioning_id_and_mentioned_id", unique: true
+    t.index ["mentioning_id"], name: "index_mentions_on_mentioning_id"
+  end
+
   create_table "reports", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "title", null: false
@@ -87,5 +97,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_24_060432) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "comments", "users"
+  add_foreign_key "mentions", "reports", column: "mentioned_id"
+  add_foreign_key "mentions", "reports", column: "mentioning_id"
   add_foreign_key "reports", "users"
 end


### PR DESCRIPTION
以下の機能を実装しています
・日報の本文に別の日報のURLを含めることで言及を作成できる
・言及先の日報に言及元の日報のタイトル、作成者を表示する
・日報の編集から言及の更新、削除ができる
・日報が削除されれば言及も消える